### PR TITLE
Util & Table Creation redux

### DIFF
--- a/src/app/bot/components/groups.js
+++ b/src/app/bot/components/groups.js
@@ -19,8 +19,8 @@ const groups = {
         if (userType === 'mod') defaultGroupID = 1;
         if ($.user.isAdmin(username)) defaultGroupID = 0;
 
-        const _groupID = $.util.num.validate($.db.get('users', 'permission', { name: username }));
-        if (!$.util.val.isNullLike(_groupID) && _groupID >= 0) {
+        const _groupID = $.db.get('users', 'permission', { name: username });
+        if (!$.util.isNil(_groupID) && _groupID >= 0) {
             return _groupID;
         } else {
             Logger.trace(`getUserGroup:: assigning default group to ${username} (level ${defaultGroupID})`);

--- a/src/app/bot/core.js
+++ b/src/app/bot/core.js
@@ -160,13 +160,29 @@ const coreMethods = {
         countRows(table, what, where, options) {
             return db.bot.data.countRows(table, what, where, options);
         },
-        addTable(name) {
+        getModuleConfig(moduleName, key, defaultValue) {
+            return db.bot.data.get('extension_settings', 'value', {
+                extension: moduleName,
+                type: 'module'
+            }, defaultValue);
+        },
+        setModuleConfig(moduleName, key, value) {
+            return db.bot.data.set('extension_settings', 'value', {
+                extension: moduleName,
+                type: 'module'
+            }, value);
+        },
+        addTable(name, keyed) {
             if (!name || typeof name !== 'string') {
                 Logger.bot(`ERR in core#addTable:: Expected parameter 'name' to be a string, received ${typeof name}`);
                 return;
             }
 
-            db.addTable(name, ['key', 'value', 'info'], true);
+            const columns = keyed
+                ? [{ name: 'id', type: 'integer', primaryKey: true, autoIncrement: true }, 'value', 'info']
+                : ['key', 'value', 'info'];
+
+            db.addTable(name, columns, true);
         },
         addTableCustom(name, columns) {
             if (arguments.length < 2 || typeof name !== 'string' || !Array.isArray(columns)) {
@@ -328,6 +344,9 @@ const _loadTables = function() {
     db.addTable('settings', [{ name: 'key', unique: true },
         'value', 'info'
     ], true)
+    .addTable('extension_settings', [
+        'extension', 'type', 'key', 'value', 'info'
+    ], true, { compositeKey: ['extension', 'type'] })
     .addTable('users', [
         { name: 'name', unique: true },
         { name: 'permission', type: 'int' },

--- a/src/app/bot/modules/games/8ball.js
+++ b/src/app/bot/modules/games/8ball.js
@@ -60,10 +60,7 @@ function initResponses() {
     $.addSubcommand('remove', '8ball', { permLevel: 0, status: true });
     $.addSubcommand('edit', '8ball', { permLevel: 0, status: true });
 
-    $.db.addTableCustom('ball', [
-        { name: 'id', type: 'integer', primaryKey: true, autoIncrement: true },
-        'value'
-    ]);
+    $.db.addTable('ball', true);
 
     if (!$.db.countRows('ball')) initResponses();
 })();

--- a/src/app/bot/modules/main/points.js
+++ b/src/app/bot/modules/main/points.js
@@ -6,7 +6,7 @@ module.exports.points = (event) => {
     }
 
     if (action === 'add') {
-        if (event.args.length < 3 || !$.util.num.validate(param2)) {
+        if (event.args.length < 3 || !$.util.str.isNumeric(param2)) {
             $.say(event.sender, `Usage: !points add [username] [amount]`);
             return;
         }
@@ -18,7 +18,7 @@ module.exports.points = (event) => {
     }
 
     if (action === 'remove') {
-        if (event.args.length < 3 || !$.util.num.validate(param2)) {
+        if (event.args.length < 3 || !$.util.str.isNumeric(param2)) {
             $.say(event.sender, `Usage: !points remove [username] [amount]`);
             return;
         }
@@ -30,7 +30,7 @@ module.exports.points = (event) => {
     }
 
     if (action === 'gift') {
-        if (event.args.length < 3 || !$.util.num.validate(param2)) {
+        if (event.args.length < 3 || !$.util.str.isNumeric(param2)) {
             $.say(event.sender, `Usage: !points gift [username] [amount]`);
             return;
         }

--- a/src/app/main/utils/util.js
+++ b/src/app/main/utils/util.js
@@ -1,15 +1,20 @@
 import _ from 'lodash';
 
 export default {
+    /**
+     * String functions {string}
+     */
+
     str: {
         /**
-         * Check if a string is a whole number
+         * Check if a string is numeric
          * @param {string} value
          * @returns {boolean}
-         * @reference http://stackoverflow.com/a/24457420
          */
         isNumeric(value) {
-            return (/^\d+$/).test(value);
+            if (_.isFinite(value)) return true;
+            if (!_.isString(value)) return false;
+            return (/^((?:\d+)?\.?(?:\d+)?)$/).test(value);
         },
         /**
          * Check if a string is either of 'true' or 'false'
@@ -20,34 +25,46 @@ export default {
             return (value === 'true' || value === 'false');
         }
     },
+
+    /**
+     * Number functions {number}
+     */
+
     num: {
-        /**
-         * Coerce a value to a number if possible
-         * @param {*} value
-         * @returns {number|null} 'number' if parsed, else null
-         */
         validate(value) {
-            if (!isNaN(parseInt(value))) {
-                return parseInt(value);
-            } else {
-                return null;
-            }
+
         },
         isFinite: _.isFinite,
         random: _.random
     },
+
+    /**
+     * Array functions {Array}
+     */
+
     arr: {
         random: _.sample,
         shuffle: _.shuffle
     },
-    val: {
-        /**
-         * Check if a value is null or undefined
-         * @param {*} value
-         * @returns {boolean} 'true' if value is null or undefined
-         */
-        isNullLike(value) {
-            return value == null;
-        }
-    }
+
+    /**
+     * General value functions {*}
+     */
+
+    /**
+     * Coerce a value to a number if possible, else return 0
+     * @param {*} value
+     * @param {boolean} round - rounds to an integer if true
+     * @returns {number}
+     */
+    toNumber(value, round) {
+        if (round) return _.toInteger(value);
+        return _.toFinite(value);
+    },
+    /**
+     * Check if a value is null or undefined
+     * @param {*} value
+     * @returns {boolean} 'true' if value is null or undefined
+     */
+    isNil: _.isNil
 };


### PR DESCRIPTION
### Util structure

The util library going forward is probably going to utilize (alias) lodash methods more. `str.validate` has been removed since it wasn't all that useful, and has been 'replaced' by a more general `toNumber` function to coerce values to numbers, optionally rounded to integers. `isNullLike` was already using the same logic as lodash to determine if a value was `null` or `undefined` so it's been removed & replaced by `isNil` which just references the lodash method.

The groups component, points module, db, and bot core have been updated to use the new util structure.
### Database table creation

This PR also includes changes to the bot core's `db.addTable` function to make it more universally useful. Adding a second argument set to `true` makes the inserted table a 'keyed' table containing the columns `id`, `value`, and `info` where `id` is an autoincrementing primary key. This should be used for things such as 8ball where values are selected by an id and such ids shouldn't necessarily be given to other values. A falsey `keyed` parameter here will insert a standard table with columns `key`, `value`, and `info`.

More advanced tables can be created using `db.addTableCustom`.
### Easier db usage for extensions

The bot db has also been made easier to use for extensions by adding a standard `extension_settings` table. Entries are identified by a composite key based on their extension type (`module`, `component`, or `helper`) and their name. The composite key will prevent clashing if a component shares a name with a module for example.

Two new core functions use this extension table to insert as type `module`:
- `$.db.getModuleConfig(moduleName, key, defaultValue)` retrieves a `value`. if the `key` doesn't exist for `moduleName`, it will be set with `defaultValue` as its value.
- `$.db.setModuleConfig(moduleName, key, value)` sets `key` to `value` for `moduleName`
