### PR TITLE
Add custom commands

### DIFF
--- a/src/app/bot/components/commandRegistry.js
+++ b/src/app/bot/components/commandRegistry.js
@@ -52,7 +52,7 @@ const registerCommand = function(name, module, options) {
     };
     Object.assign(obj, options);
 
-    _registerCommand(obj, response);
+    _registerCommand(obj, module);
 };
 
 const registerSubcommand = function(name, parent, options) {

--- a/src/app/bot/components/commandRegistry.js
+++ b/src/app/bot/components/commandRegistry.js
@@ -75,6 +75,8 @@ const registerSubcommand = function(name, parent, options) {
 
 const registerCustomCommand = function(name, response) {
     if (!name || !response) return false;
+    name = name.toLowerCase();
+    
     if (commands.hasOwnProperty(name)) {
         Logger.bot(`Could not add custom command '${name}'. Name already in use.`);
         return false;
@@ -100,6 +102,20 @@ const registerCustomCommand = function(name, response) {
     return true;
 };
 
+const unregisterCustomCommand = function(name) {
+    if (!name) return;
+    name = name.toLowerCase();
+    
+    if (commands.hasOwnProperty(name) && commands[name].custom) {
+        delete commands[name];
+        db.bot.data.del('commands', { name, module: 'custom' });
+        return true;
+    } else {
+        Logger.bot(`Could not remove command '${name}'. Doesn't exist or is not custom.`);
+        return false;
+    }
+};
+
 const _unregister = function(all) {
     if (all) {
         modules = [];
@@ -111,6 +127,7 @@ $.on('bot:ready', () => {
     $.addCommand = registerCommand;
     $.addSubcommand = registerSubcommand;
     $.command.addCustom = registerCustomCommand;
+    $.command.removeCustom = unregisterCustomCommand;
 
     Logger.bot('Listening for commands.');
 });

--- a/src/app/bot/components/commandRegistry.js
+++ b/src/app/bot/components/commandRegistry.js
@@ -76,24 +76,24 @@ const registerSubcommand = function(name, parent, options) {
 const addCustomCommand = function(name, response) {
     if (!name || !response) return false;
     name = name.toLowerCase();
-    
+
     if (commands.hasOwnProperty(name)) {
         Logger.bot(`Could not add custom command '${name}'. Name already in use.`);
         return false;
     }
-    
+
     _registerCustomCommand(name);
     _dbInsertCustomCommand(name, response);
 
     Logger.trace(`Added custom command:: '${name}'`);
-    
+
     return true;
 };
 
 const deleteCustomCommand = function(name) {
     if (!name) return;
     name = name.toLowerCase();
-    
+
     if (commands.hasOwnProperty(name) && commands[name].custom) {
         _unregisterCustomCommand(name);
         _dbDeleteCustomCommand(name);
@@ -126,7 +126,7 @@ const _dbDeleteCustomCommand = function(name) {
 
 const _loadCustomCommands = function() {
     const arr = db.bot.data.getRows('commands', { module: 'custom' });
-    
+
     for (let cmd of arr) {
         _registerCustomCommand(cmd.name);
     }
@@ -150,8 +150,8 @@ $.on('bot:ready', () => {
 
 export {
     commands as default,
-    addCustomCommand as addCustomCommand,
-    deleteCustomCommand as deleteCustomCommand,
+    addCustomCommand,
+    deleteCustomCommand,
     _loadCustomCommands as loadCustomCommands,
     _unregister as unregister
 };

--- a/src/app/bot/core.js
+++ b/src/app/bot/core.js
@@ -287,11 +287,11 @@ const coreMethods = {
         try {
             if (this.command.isCustom(event.command)) {
                 const response = this.db.get('commands', 'response', { name: event.command, module: 'custom' });
-                this.say(event.sender, this.params(response));
+                this.say(event.sender, this.params(event, response));
             } else {
                 this.command.getRunner(event.command)(event);
             }
-            
+
             this.command.startCooldown(event.command, event.sender, subcommand);
             this.points.sub(event.sender, commandPrice);
         } catch (err) {
@@ -417,7 +417,7 @@ const _loadModules = function() {
     userModules();
     loaders.sys = require('require-directory')(module, './modules');
     loaders.user = require('require-directory')(module, Settings.get('userModulePath'));
-    
+
     commandRegistry.loadCustomCommands();
 };
 

--- a/src/app/bot/core.js
+++ b/src/app/bot/core.js
@@ -417,6 +417,8 @@ const _loadModules = function() {
     userModules();
     loaders.sys = require('require-directory')(module, './modules');
     loaders.user = require('require-directory')(module, Settings.get('userModulePath'));
+    
+    commandRegistry.loadCustomCommands();
 };
 
 const _unloadModules = function(botDir) {

--- a/src/app/bot/modules/main/admin.js
+++ b/src/app/bot/modules/main/admin.js
@@ -122,7 +122,7 @@ module.exports.command = (event) => {
         const newResponse = event.subArgs.slice(1).join(' ');
 
         $.db.set('commands', { response: newResponse }, { name: param1, module: 'custom' });
-        $.say(event.sender, `Custom command '${param1} edited.`);
+        $.say(event.sender, `Custom command '${param1}' edited.`);
 
         return;
     }

--- a/src/app/bot/modules/main/admin.js
+++ b/src/app/bot/modules/main/admin.js
@@ -1,9 +1,9 @@
 import moment from 'moment';
 
 module.exports.command = (event) => {
-    const [action, param1, param2] = event.args;
+    const [param1, param2] = event.subArgs;
 
-    if (action === 'enable') {
+    if (event.subcommand === 'enable') {
         if (event.args.length < 2) {
             return $.say(event.sender, `Usage: !command enable [command name]`);
         }
@@ -29,7 +29,7 @@ module.exports.command = (event) => {
         return;
     }
 
-    if (action === 'disable') {
+    if (event.subcommand === 'disable') {
         if (event.args.length < 2) {
             return $.say(event.sender, `Usage: !command disable [command name]`);
         }
@@ -55,7 +55,7 @@ module.exports.command = (event) => {
         return;
     }
 
-    if (action === 'permission') {
+    if (event.subcommand === 'permission') {
         if (event.args.length < 2) {
             return $.say(event.sender, `Usage: !command permission [command name] [level]`);
         }
@@ -69,20 +69,73 @@ module.exports.command = (event) => {
 
         return;
     }
+    
+    if (event.subcommand === 'add') {
+        if (event.subArgs.length < 2) {
+            return $.say(event.sender, `Usage: !command add [command name] [response]`);
+        }
+        
+        if ($.command.exists(param1)) {
+            return $.say(event.sender, `A command by that name already exists.`);
+        }
+        
+        $.command.addCustom(param1, event.subArgString);
+        $.say(event.sender, `Custom command '${param1} added.`);
+        
+        return;
+    }
+    
+    if (event.subcommand === 'remove') {
+        if (!event.subArgs[0]) {
+            return $.say(event.sender, `Usage: !command remove [command name]`);
+        }
+        
+        if (!$.command.exists(param1)) {
+            return $.say(event.sender, `There is no command by the name of '${param1}'.`);
+        }
+        
+        if (!$.command.isCustom(param1)) {
+            return $.say(event.sender, `That command is installed in a module.`);
+        }
+        
+        $.command.removeCustom(param1);
+        $.say(event.sender, `Custom command '${param1} removed.`);
+        
+        return;
+    }
+    
+    if (event.subcommand === 'edit') {
+        if (event.subArgs.length < 2) {
+            return $.say(event.sender, `Usage: !command edit [command name] [response]`);
+        }
+        
+        if (!$.command.exists(param1)) {
+            return $.say(event.sender, `There is no command by the name of '${param1}'.`);
+        }
+        
+        if (!$.command.isCustom(param1)) {
+            return $.say(event.sender, `That command is installed in a module.`);
+        }
+        
+        const newResponse = event.subArgs.slice(1).join(' ');
+        
+        $.db.set('commands', { response: newResponse }, { name: param1, module: 'custom' });
+        $.say(event.sender, `Custom command '${param1} edited.`);
+        
+        return;
+    }
 
-    $.say(event.sender, `Usage: !command [enable | disable | permission]`);
+    $.say(event.sender, `Usage: !command [add | remove | edit | enable | disable | permission]`);
 };
 
 module.exports.whisperMode = (event) => {
-    let action = event.args[0];
-
-    if (action === 'enable') {
+    if (event.subcommand === 'enable') {
         $.settings.set('whisperMode', true);
         $.say(event.sender, 'Whisper mode enabled.');
         return;
     }
 
-    if (action === 'disable') {
+    if (event.subcommand === 'disable') {
         $.settings.set('whisperMode', false);
         $.say(event.sender, 'Whisper mode disabled.');
         return;
@@ -112,12 +165,24 @@ module.exports.lastSeen = (event) => {
         permLevel: 0,
         status: true
     });
+    
+    $.addSubcommand('enable', 'command', { permLevel: 0, status: true });
+    $.addSubcommand('disable', 'command', { permLevel: 0, status: true });
+    $.addSubcommand('permission', 'command', { permLevel: 0, status: true });
+    $.addSubcommand('add', 'command', { permLevel: 0, status: true });
+    $.addSubcommand('remove', 'command', { permLevel: 0, status: true });
+    $.addSubcommand('edit', 'command', { permLevel: 0, status: true });
+    
     $.addCommand('whispermode', './modules/main/admin', {
         handler: 'whisperMode',
         cooldown: 0,
         permLevel: 0,
         status: true
     });
+    
+    $.addSubcommand('enable', 'whispermode', { permLevel: 0, status: true });
+    $.addSubcommand('disable', 'whispermode', { permLevel: 0, status: true });
+    
     $.addCommand('lastseen', './modules/main/admin', {
         handler: 'lastSeen',
         status: true

--- a/src/app/bot/modules/main/admin.js
+++ b/src/app/bot/modules/main/admin.js
@@ -122,7 +122,7 @@ module.exports.command = (event) => {
         const newResponse = event.subArgs.slice(1).join(' ');
 
         $.db.set('commands', { response: newResponse }, { name: param1, module: 'custom' });
-        $.say(event.sender, `Custom command '${param1}' edited.`);
+        $.say(event.sender, `Custom command '${param1}' modified.`);
 
         return;
     }

--- a/src/app/bot/modules/main/admin.js
+++ b/src/app/bot/modules/main/admin.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 module.exports.command = (event) => {
-    const [param1, param2] = event.subArgs;
+    const [, param1, param2] = event.args;
 
     if (event.subcommand === 'enable') {
         if (event.args.length < 2) {
@@ -69,59 +69,61 @@ module.exports.command = (event) => {
 
         return;
     }
-    
+
     if (event.subcommand === 'add') {
         if (event.subArgs.length < 2) {
             return $.say(event.sender, `Usage: !command add [command name] [response]`);
         }
-        
+
         if ($.command.exists(param1)) {
             return $.say(event.sender, `A command by that name already exists.`);
         }
-        
-        $.command.addCustom(param1, event.subArgString);
-        $.say(event.sender, `Custom command '${param1} added.`);
-        
+
+        const response = event.subArgs.slice(1).join(' ');
+
+        $.command.addCustom(param1, response);
+        $.say(event.sender, `Custom command '${param1}' added.`);
+
         return;
     }
-    
+
     if (event.subcommand === 'remove') {
         if (!event.subArgs[0]) {
             return $.say(event.sender, `Usage: !command remove [command name]`);
         }
-        
+
         if (!$.command.exists(param1)) {
             return $.say(event.sender, `There is no command by the name of '${param1}'.`);
         }
-        
+
         if (!$.command.isCustom(param1)) {
             return $.say(event.sender, `That command is installed in a module.`);
         }
-        
+
         $.command.removeCustom(param1);
-        $.say(event.sender, `Custom command '${param1} removed.`);
-        
+        $.say(event.sender, `Custom command '${param1}' removed.`);
+
         return;
     }
-    
+
     if (event.subcommand === 'edit') {
         if (event.subArgs.length < 2) {
             return $.say(event.sender, `Usage: !command edit [command name] [response]`);
         }
-        
+
         if (!$.command.exists(param1)) {
             return $.say(event.sender, `There is no command by the name of '${param1}'.`);
         }
-        
+
         if (!$.command.isCustom(param1)) {
             return $.say(event.sender, `That command is installed in a module.`);
         }
-        
+
         const newResponse = event.subArgs.slice(1).join(' ');
-        
+
         $.db.set('commands', { response: newResponse }, { name: param1, module: 'custom' });
         $.say(event.sender, `Custom command '${param1} edited.`);
-        
+
         return;
     }
 
@@ -165,24 +167,24 @@ module.exports.lastSeen = (event) => {
         permLevel: 0,
         status: true
     });
-    
+
     $.addSubcommand('enable', 'command', { permLevel: 0, status: true });
     $.addSubcommand('disable', 'command', { permLevel: 0, status: true });
     $.addSubcommand('permission', 'command', { permLevel: 0, status: true });
     $.addSubcommand('add', 'command', { permLevel: 0, status: true });
     $.addSubcommand('remove', 'command', { permLevel: 0, status: true });
     $.addSubcommand('edit', 'command', { permLevel: 0, status: true });
-    
+
     $.addCommand('whispermode', './modules/main/admin', {
         handler: 'whisperMode',
         cooldown: 0,
         permLevel: 0,
         status: true
     });
-    
+
     $.addSubcommand('enable', 'whispermode', { permLevel: 0, status: true });
     $.addSubcommand('disable', 'whispermode', { permLevel: 0, status: true });
-    
+
     $.addCommand('lastseen', './modules/main/admin', {
         handler: 'lastSeen',
         status: true

--- a/src/app/db.js
+++ b/src/app/db.js
@@ -455,6 +455,14 @@ data.bot = {
                 return response;
             }
         },
+        getRows(table, where, order) {
+            const response = botDB.get(table, '*', where, order);
+            if (response && Array.isArray(response)) {
+                return response;
+            } else {
+                return [];
+            }
+        },
         countRows(table, what, where, options) {
             const response = parseInt(botDB.count(table, what, where, options));
             if (_.isFinite(response)) {

--- a/src/app/db.js
+++ b/src/app/db.js
@@ -485,13 +485,13 @@ data.bot = {
         }
     },
 
-    addCommand(name, cooldown, permission, status, price, module) {
+    addCommand(name, cooldown, permission, status, price, module, response) {
         if (!name || !module) {
             Logger.bot('Failed to add command. Name & module are required.');
             return;
         }
         botDB.put('commands', {
-            name, cooldown, permission, status, price, module
+            name, cooldown, permission, status, price, module, response
         }, { conflict: 'ignore' }, errHandler);
         return this;
     },


### PR DESCRIPTION
Expands the `!command` command with the ability to `add`, `remove` and `edit` simple commands ( though they do have parameter replacement ).

Usages:

> !command add hello Hi there!
> !hello
> `Hi there!`
> 
> !command add sup Yo (random)!
> !sup
> `Yo citycide!`
> 
> !command remove hello
> `Custom command 'hello' removed.`
> 
> !command edit sup This should have said (random) is cool.
> `Custom command 'sup' modified.`
> !sup
> `This should have said thecitybot is cool.`
