### PR TITLE
feat(transit): add socket bus

### DIFF
--- a/src/main/components/transit.js
+++ b/src/main/components/transit.js
@@ -1,15 +1,20 @@
 import { EventEmitter } from 'events'
+import { io } from './server'
 import ipcMain from '../utils/ipc-main'
 
 class Transit extends EventEmitter {
-  on (channel, fn, bus = false) {
+  on (channel, fn, bus) {
     switch (bus) {
-      case true:
+      case 'all':
         super.on(channel, fn)
         ipcMain.on(channel, fn)
+        io.on('connection' socket => socket.on(channel, fn))
         break
-      case false:
+      case 'main':
         super.on(channel, fn)
+        break
+      case 'io':
+        io.once('connection' socket => socket.on(channel, fn))
         break
       case 'ipc':
       default:
@@ -17,14 +22,18 @@ class Transit extends EventEmitter {
     }
   }
 
-  once (channel, fn, bus = false) {
+  once (channel, fn, bus) {
     switch (bus) {
-      case true:
+      case 'all':
         super.once(channel, fn)
         ipcMain.once(channel, fn)
+        io.once('connection' socket => socket.once(channel, fn))
         break
-      case false:
+      case 'main':
         super.once(channel, fn)
+        break
+      case 'io':
+        io.once('connection' socket => socket.once(channel, fn))
         break
       case 'ipc':
       default:
@@ -32,14 +41,18 @@ class Transit extends EventEmitter {
     }
   }
 
-  emit (channel, data, bus = false) {
+  emit (channel, data, bus) {
     switch (bus) {
-      case true:
+      case 'all':
         super.emit(channel, data)
         ipcMain.sendToAll(channel, data)
+        io.emit(channel, data)
         break
-      case false:
+      case 'main':
         super.emit(channel, data)
+        break
+      case 'io':
+        io.emit(channel, data)
         break
       case 'ipc':
       default:

--- a/src/main/services/Streamlabs/index.js
+++ b/src/main/services/Streamlabs/index.js
@@ -74,7 +74,7 @@ async function interval (instance) {
 
 function handleResponse (donations) {
   if (!tips.length) {
-    donations.reverse().map(tip => {
+    donations.reverse().forEach(tip => {
       if (!tips.includes(tip.id)) tips.push(tip.id)
 
       // eslint-disable-next-line
@@ -91,7 +91,7 @@ function handleResponse (donations) {
       // db.addTip()
     })
   } else {
-    donations.reverse().map(tip => {
+    donations.reverse().forEach(tip => {
       if (!tips.includes(tip.id)) {
         tips.push(tip.id)
 
@@ -103,7 +103,7 @@ function handleResponse (donations) {
             timestamp: tip.created_at
           },
           type: 'tip'
-        })
+        }, 'all')
       }
     })
   }

--- a/src/main/services/Streamtip/index.js
+++ b/src/main/services/Streamtip/index.js
@@ -59,7 +59,7 @@ function listen (instance) {
       },
       type: 'tip'
     }
-    transit.emit('alert:tip:event', thisEvent)
+    transit.emit('alert:tip:event', thisEvent, 'all')
   })
 
   instance.on('error', err => {

--- a/src/main/services/TipeeeStream/index.js
+++ b/src/main/services/TipeeeStream/index.js
@@ -51,7 +51,7 @@ function listen (instance) {
         timestamp: moment(data.event.created_at).valueOf()
       },
       type: 'tip'
-    })
+    }, 'all')
   })
 
   return instance.removeAllListeners

--- a/src/main/services/Twitch/index.js
+++ b/src/main/services/Twitch/index.js
@@ -170,7 +170,7 @@ export default class TwitchClass {
   }
 
   eventHandler () {
-    transit.on('test:follower', username => {
+    transit.on('alert:follower', username => {
       let thisTest
       this.resolveUser(username, userObj => {
         if (userObj.resolved) {
@@ -196,7 +196,7 @@ export default class TwitchClass {
       })
     })
 
-    transit.on('test:host', hostObj => {
+    transit.on('alert:host', hostObj => {
       let thisTest
       this.resolveUser(hostObj.user.display_name, userObj => {
         if (userObj.resolved) {
@@ -223,7 +223,7 @@ export default class TwitchClass {
       })
     })
 
-    transit.on('test:tip', data => {
+    transit.on('alert:tip', data => {
       let thisTest = {
         user: {
           name: data.user.name,
@@ -363,26 +363,26 @@ TwitchClass.prototype.actOnQueue = function (data, type) {
   switch (type) {
     case 'follower':
       log.trace('Queue item is a follower event.')
-      transit.fire('alert:follow', data)
-      transit.fire('alert:follow:event', {
+      transit.emit('alert:follow', data, 'all')
+      transit.emit('alert:follow:event', {
         twitchid: data._id,
         username: data.display_name,
         timestamp: moment(data.created_at, 'x').fromNow(),
         evtype: 'follower',
         notifications: data.notifications
-      })
+      }, 'all')
       break
     case 'host':
       log.trace('Queue item is a host event.')
-      transit.fire('alert:host', data)
+      transit.emit('alert:host', data, 'all')
       break
     case 'subscriber':
       log.trace('Queue item is a subscriber event.')
-      transit.fire('alert:subscriber', data)
+      transit.emit('alert:subscriber', data, 'all')
       break
     case 'tip':
       log.trace('Queue item is a tip event.')
-      transit.fire('alert:tip', data)
+      transit.emit('alert:tip', data, 'all')
       break
     default:
       log.debug(`ERR in actOnQueue:: Queue item is of unknown type '${type}'`)

--- a/src/main/services/Twitch/index.js
+++ b/src/main/services/Twitch/index.js
@@ -170,7 +170,7 @@ export default class TwitchClass {
   }
 
   eventHandler () {
-    transit.on('alert:follower', username => {
+    transit.on('alert:follower:test', username => {
       let thisTest
       this.resolveUser(username, userObj => {
         if (userObj.resolved) {
@@ -196,7 +196,7 @@ export default class TwitchClass {
       })
     })
 
-    transit.on('alert:host', hostObj => {
+    transit.on('alert:host:test', hostObj => {
       let thisTest
       this.resolveUser(hostObj.user.display_name, userObj => {
         if (userObj.resolved) {
@@ -223,7 +223,7 @@ export default class TwitchClass {
       })
     })
 
-    transit.on('alert:tip', data => {
+    transit.on('alert:tip:test', data => {
       let thisTest = {
         user: {
           name: data.user.name,

--- a/src/main/services/events.js
+++ b/src/main/services/events.js
@@ -17,7 +17,7 @@ services.forEach(({ name, file }) => {
 
     const { activate } = require(file)
     activate(data)
-  }, 'ipc')
+  })
 
   transit.on(`service:${name}:disable`, () => {
     const instance = getInstance(name)
@@ -27,8 +27,8 @@ services.forEach(({ name, file }) => {
     const { deactivate } = require(file)
     deactivate()
     instances.delete(name)
-  }, 'ipc')
+  })
 })
 
-transit.on('service:all:start', () => initServices, 'ipc')
-transit.on('service:all:stop', () => instances.forEach(v => v.stop()), 'ipc')
+transit.on('service:all:start', () => initServices)
+transit.on('service:all:stop', () => instances.forEach(v => v.stop()))

--- a/src/renderer/components/control.vue
+++ b/src/renderer/components/control.vue
@@ -42,9 +42,7 @@
             ></ui-textbox>
             <ui-button
               @click.stop.prevent="sendFollow" color="primary" class="is-pulled-right"
-            >
-              SEND
-            </ui-button>
+            >SEND</ui-button>
           </form>
         </ui-collapsible>
         <ui-collapsible id="control-subscriber" header="SUBSCRIBER" :open="true">
@@ -61,9 +59,7 @@
             ></ui-textbox>
             <ui-button
               @click.stop.prevent="sendSub" color="primary" class="is-pulled-right"
-            >
-              SEND
-            </ui-button>
+            >SEND</ui-button>
           </form>
         </ui-collapsible>
         <ui-collapsible id="control-now-playing" header="NOW PLAYING" :open="true">
@@ -94,9 +90,7 @@
             ></ui-textbox>
             <ui-button
               @click.stop.prevent="sendSong(false)" color="primary" class="is-pulled-right"
-            >
-              SEND
-            </ui-button>
+            >SEND</ui-button>
           </form>
         </ui-collapsible>
       </div>
@@ -115,9 +109,7 @@
             ></ui-textbox>
             <ui-button
               @click.stop.prevent="sendHost" color="primary" class="is-pulled-right"
-            >
-              SEND
-            </ui-button>
+            >SEND</ui-button>
           </form>
         </ui-collapsible>
         <ui-collapsible id="control-tip" header="TIP" :open="true">
@@ -138,9 +130,7 @@
             ></ui-textbox>
             <ui-button
               @click.stop.prevent="sendTip" color="primary" class="is-pulled-right"
-            >
-              SEND
-            </ui-button>
+            >SEND</ui-button>
           </form>
         </ui-collapsible>
       </div>
@@ -152,6 +142,8 @@
   import { UiButton, UiIconButton, UiCollapsible, UiTextbox } from 'keen-ui'
   import { mapGetters } from 'vuex'
   import icon from 'vue-awesome'
+  
+  import transit from './js/transit'
 
   export default {
     data () {
@@ -160,19 +152,45 @@
 
     methods: {
       sendFollow (event, username) {
-        console.log(username ? username : this.follow.name)
+        const name = username ? username : this.follow.name
+        transit.fire('alert:follow:test', name)
       },
       sendHost () {
-        console.log(this.host.name)
+        transit.fire('alert:host:test', {
+          user: {
+            display_name: this.host.name
+          },
+          viewers: this.host.viewers
+        })
       },
       sendSub () {
-        console.log(this.sub.name)
+        if (!this.sub.months) {
+          transit.fire('alert:sub:test', this.sub.name)
+        } else {
+          transit.fire('alert:resub:test', {
+            user: {
+              display_name: this.sub.name
+            },
+            months: this.sub.months
+          })
+        }
       },
       sendTip () {
-        console.log(this.tip.name)
+        const formattedAmount = '$' + this.tip.amount
+          .toFixed(2)
+          .replace(/(\d)(?=(\d{3})+\.)/g, '$1,')
+
+        transit.fire('alert:tip:test', {
+          user: {
+            name: this.tip.name
+          },
+          amount: formattedAmount,
+          message: this.tip.message
+        })
       },
       sendSong (current) {
-        console.log(current ? this.music.current : this.music.test)
+        const song = current ? this.music.current : this.music.test
+        transit.fire('alert:music:test', song)
       }
     },
 


### PR DESCRIPTION
BREAKING CHANGE: the `bus` argument to transit methods no longer uses a mix of Boolean & String values. It must be a a string, one of 'all', 'main', or 'io' or will otherwise default to 'ipc'.
