### PR TITLE
refactor(bot): use lodash shorthands

### DIFF
--- a/src/main/components/bot/extensions/cooldown/cooldown-component.js
+++ b/src/main/components/bot/extensions/cooldown/cooldown-component.js
@@ -88,7 +88,7 @@ const cooldown = {
 
     const cooldowns = $.cache.get('cooldowns', [])
 
-    const active = _.find(cooldowns, v => v.name === cmd && v.scope === scope && v.sub === sub)
+    const active = _.find(cooldowns, { name: cmd, scope, sub })
 
     if (!active) return false
 
@@ -121,7 +121,7 @@ const cooldown = {
 
     const cooldowns = $.cache.get('cooldowns', [])
 
-    return _.findIndex(cooldowns, v => v.name === cmd && v.scope === scope && v.sub === sub)
+    return _.findIndex(cooldowns, { name: cmd, scope, sub })
   }
 }
 


### PR DESCRIPTION
Change the predicate passed to `_.find` & `_.findIndex` from a function to an object to use the `_.matches` shorthand.
