### PR TITLE
refactor(bot): minor changes to command registry

### DIFF
--- a/src/common/utils/helpers.js
+++ b/src/common/utils/helpers.js
@@ -10,7 +10,7 @@ export function to (value) {
 
 Object.assign(is, {
   string: _.isString,
-  number: _.isNumber,
+  number: isNumber,
   finite: _.isFinite,
   object: _.isPlainObject,
   array: _.isArray,
@@ -35,6 +35,10 @@ Object.assign(to, {
   boolean: toBoolean
 })
 
+function isNumber (value, rounded = true) {
+  return rounded ? _.isSafeInteger(value) : _.isFinite(value)
+}
+
 function isNumeric (value) {
   if (_.isFinite(value)) return true
   if (!_.isString(value)) return false
@@ -55,8 +59,8 @@ function toBoolean (value) {
   return value === 'true'
 }
 
-function toNumber (value, round) {
-  return round ? _.toInteger(value) : _.toFinite(value)
+function toNumber (value, round = true) {
+  return round ? _.toSafeInteger(value) : _.toFinite(value)
 }
 
 export async function sleep (ms) {

--- a/src/main/components/bot/command-registry.js
+++ b/src/main/components/bot/command-registry.js
@@ -1,6 +1,6 @@
 import callsites from 'callsites'
 import db from 'common/components/db'
-import log from '../../../common/utils/logger'
+import log from 'common/utils/logger'
 
 let modules = []
 let commands = {}
@@ -125,10 +125,7 @@ const _dbDeleteCustomCommand = async function (name) {
 
 const _loadCustomCommands = async function () {
   const arr = await db.bot.data.getRows('commands', { module: 'custom' })
-
-  for (let cmd of arr) {
-    _registerCustomCommand(cmd.name)
-  }
+  arr.map(({ name }) => _registerCustomCommand(name))
 }
 
 const _unregister = function (all) {

--- a/src/main/components/bot/extensions/couch/ext.json
+++ b/src/main/components/bot/extensions/couch/ext.json
@@ -6,7 +6,7 @@
     "module": "./module.js",
     "component": "",
     "interface": "",
-    "language": ""
+    "language": "./lang.js"
   },
   "author": "citycide <thecitycide@gmail.com>",
   "homepage": "github.com/citycide/singularity"

--- a/src/main/components/bot/extensions/couch/lang.js
+++ b/src/main/components/bot/extensions/couch/lang.js
@@ -1,5 +1,5 @@
 export default function ($) {
-  $.weave.set('did-not-find', 'You didn't find any {0} in the couch this time.')
+  $.weave.set('did-not-find', `You didn't find any {0} in the couch this time.`)
   $.weave.set('found-points', 'You found {0} in the couch!')
   
   $.weave.set('multi.usage', 'Usage: !couch multi (multiplier) » currently set to {0}')

--- a/src/main/components/bot/extensions/couch/lang.js
+++ b/src/main/components/bot/extensions/couch/lang.js
@@ -1,0 +1,7 @@
+export default function ($) {
+  $.weave.set('did-not-find', 'You didn't find any {0} in the couch this time.')
+  $.weave.set('found-points', 'You found {0} in the couch!')
+  
+  $.weave.set('multi.usage', 'Usage: !couch multi (multiplier) » currently set to {0}')
+  $.weave.set('multi.success', 'Multiplier for !couch is now set to {0}')
+}

--- a/src/main/components/bot/extensions/couch/module.js
+++ b/src/main/components/bot/extensions/couch/module.js
@@ -35,10 +35,10 @@ export async function couch (e, $) {
     }
 
     if (payout === 0) {
-      $.say(e.sender, `You didn't find any ${await $.points.getName()} in the couch this time.`)
+      $.say(e.sender, $.weave('did-not-find', await $.points.getName()))
     } else {
       await $.points.add(e.sender, payout)
-      $.say(e.sender, `You found ${await $.points.str(payout)} in the couch.`)
+      $.say(e.sender, $.weave('found-points', await $.points.str(payout)))
     }
 
     return
@@ -46,21 +46,18 @@ export async function couch (e, $) {
 
   if ($.is(e.subcommand, 'multi')) {
     if (!e.subArgs[0] || !$.is.numeric(e.subArgs[0])) {
-      $.say(e.sender, `Usage: !couch multi (multiplier) » currently set to ${multi}`)
+      $.say(e.sender, $.weave('multi.usage', multi))
       return
     }
 
     const newMulti = $.to.number(e.subArgs[0])
 
     await $.db.setModuleConfig('couch', 'multiplier', newMulti)
-    $.say(e.sender, `!couch multiplier set to ${newMulti}`)
+    $.say(e.sender, $.weave.('multi.success', newMulti))
   }
 }
 
 export default function ($) {
-  $.addCommand('couch', {
-    cooldown: 300
-  })
-
+  $.addCommand('couch', { cooldown: 300 })
   $.addSubcommand('multi', 'couch', { permLevel: 1 })
 }

--- a/src/main/components/bot/extensions/events/lang.js
+++ b/src/main/components/bot/extensions/events/lang.js
@@ -1,3 +1,29 @@
 export default function ($) {
-  $.weave.set()
+  $.weave.set('alerts.settings', 'Follows: {0}, Hosts: {1}, Subs: {2}, Tips: {3}')
+  
+  $.weave.set('alerts.follows.usage', 'Usage: !alerts follow (enable | disable) -- currently {0}')
+  $.weave.set('alerts.follows.enabled.success', 'Alerts for new followers enabled.')
+  $.weave.set('alerts.follows.disabled.success', 'Alerts for new followers disabled.')
+  $.weave.set('alerts.follows.response-reward', 'Thanks for the follow, {0}! +{1}')
+  $.weave.set('alerts.follows.response-no-reward', 'Thanks for the follow, {0}!')
+  
+  $.weave.set('alerts.host.usage', 'Usage: !alerts host (enable | disable) -- currently {0}')
+  $.weave.set('alerts.host.enabled.success', 'Alerts for host events enabled.')
+  $.weave.set('alerts.host.disabled.success', 'Alerts for host events disabled.')
+  $.weave.set('alerts.host.response-reward', '{0} fired up the host machine for {1} viewers. Thanks! +{2}')
+  $.weave.set('alerts.host.response-no-reward', '{0} fired up the host machine for {1} viewers. Thanks!')
+  
+  $.weave.set('alerts.sub.usage', 'Usage: !alerts sub (enable | disable) -- currently {0}')
+  $.weave.set('alerts.sub.enabled.success', 'Alerts for new subscribers enabled.')
+  $.weave.set('alerts.sub.disabled.success', 'Alerts for new subscribers disabled.')
+  $.weave.set('alerts.sub.response-reward', '{0} subscribed! +{1}!')
+  $.weave.set('alerts.sub.response-no-reward', 'Thanks for the sub, {0}!')
+  $.weave.set('alerts.sub.resub-reward', '{0} has been subbed for {1} months! +{2}')
+  $.weave.set('alerts.sub.resub-no-reward', '{0} has been subbed for {1} months!')
+  
+  $.weave.set('alerts.tip.usage', 'Usage: !alerts tip (enable | disable) -- currently {0}')
+  $.weave.set('alerts.tip.enabled.success', 'Alerts for tips enabled.')
+  $.weave.set('alerts.tip.disabled.success', 'Alerts for tips disabled.')
+  $.weave.set('alerts.tip.response-reward', '{0} tipped {1}. Thank you! PogChamp +{2}')
+  $.weave.set('alerts.tip.response-no-reward', '{0} tipped {1}. Thank you! PogChamp')
 }

--- a/src/main/components/bot/extensions/events/lang.js
+++ b/src/main/components/bot/extensions/events/lang.js
@@ -1,19 +1,19 @@
 export default function ($) {
   $.weave.set('alerts.settings', 'Follows: {0}, Hosts: {1}, Subs: {2}, Tips: {3}')
   
-  $.weave.set('alerts.follows.usage', 'Usage: !alerts follow (enable | disable) -- currently {0}')
+  $.weave.set('alerts.follows.usage', 'Usage: !alerts follow (enable | disable) » currently {0}')
   $.weave.set('alerts.follows.enabled.success', 'Alerts for new followers enabled.')
   $.weave.set('alerts.follows.disabled.success', 'Alerts for new followers disabled.')
   $.weave.set('alerts.follows.response-reward', 'Thanks for the follow, {0}! +{1}')
   $.weave.set('alerts.follows.response-no-reward', 'Thanks for the follow, {0}!')
   
-  $.weave.set('alerts.host.usage', 'Usage: !alerts host (enable | disable) -- currently {0}')
+  $.weave.set('alerts.host.usage', 'Usage: !alerts host (enable | disable) » currently {0}')
   $.weave.set('alerts.host.enabled.success', 'Alerts for host events enabled.')
   $.weave.set('alerts.host.disabled.success', 'Alerts for host events disabled.')
   $.weave.set('alerts.host.response-reward', '{0} fired up the host machine for {1} viewers. Thanks! +{2}')
   $.weave.set('alerts.host.response-no-reward', '{0} fired up the host machine for {1} viewers. Thanks!')
   
-  $.weave.set('alerts.sub.usage', 'Usage: !alerts sub (enable | disable) -- currently {0}')
+  $.weave.set('alerts.sub.usage', 'Usage: !alerts sub (enable | disable) » currently {0}')
   $.weave.set('alerts.sub.enabled.success', 'Alerts for new subscribers enabled.')
   $.weave.set('alerts.sub.disabled.success', 'Alerts for new subscribers disabled.')
   $.weave.set('alerts.sub.response-reward', '{0} subscribed! +{1}!')
@@ -21,7 +21,7 @@ export default function ($) {
   $.weave.set('alerts.sub.resub-reward', '{0} has been subbed for {1} months! +{2}')
   $.weave.set('alerts.sub.resub-no-reward', '{0} has been subbed for {1} months!')
   
-  $.weave.set('alerts.tip.usage', 'Usage: !alerts tip (enable | disable) -- currently {0}')
+  $.weave.set('alerts.tip.usage', 'Usage: !alerts tip (enable | disable) » currently {0}')
   $.weave.set('alerts.tip.enabled.success', 'Alerts for tips enabled.')
   $.weave.set('alerts.tip.disabled.success', 'Alerts for tips disabled.')
   $.weave.set('alerts.tip.response-reward', '{0} tipped {1}. Thank you! PogChamp +{2}')

--- a/src/main/components/bot/extensions/events/module.js
+++ b/src/main/components/bot/extensions/events/module.js
@@ -19,7 +19,7 @@ export async function alerts (e, $) {
       : $.weave.core('common-words.disabled')
 
     await $.settings.set('followAlerts', bool)
-    $.say(e.sender, $.weave(`alerts.follows-${type}.success`))
+    $.say(e.sender, $.weave(`alerts.follows.${type}.success`))
 
     return
   }
@@ -40,7 +40,7 @@ export async function alerts (e, $) {
       : $.weave.core('common-words.disabled')
 
     await $.settings.set('hostAlerts', bool)
-    $.say(e.sender, $.weave(`alerts.host-${type}.success`))
+    $.say(e.sender, $.weave(`alerts.host.${type}.success`))
 
     return
   }
@@ -61,7 +61,7 @@ export async function alerts (e, $) {
       : $.weave.core('common-words.disabled')
 
     await $.settings.set('subAlerts', bool)
-    $.say(e.sender, $.weave(`alerts.sub-${type}.success`))
+    $.say(e.sender, $.weave(`alerts.sub.${type}.success`))
 
     return
   }
@@ -82,7 +82,7 @@ export async function alerts (e, $) {
       : $.weave.core('common-words.disabled')
 
     await $.settings.set('tipAlerts', bool)
-    $.say(e.sender, $.weave(`alerts.tip-${type}.success`))
+    $.say(e.sender, $.weave(`alerts.tip.${type}.success`))
 
     return
   }
@@ -111,27 +111,6 @@ export async function alerts (e, $) {
   $.say(e.sender, $.weave('alerts.usage'))
 }
 
-async function followHandler (data) {
-  const events = $.cache.get('events', [])
-
-  if (await $.settings.get('followAlerts', true)) {
-    if (!events.includes(`${data.display_name}:follow`)) {
-      events.push(`${data.display_name}:follow`)
-      const reward = await $.settings.get('followReward', 50)
-
-      if (reward > 0) {
-        $.shout($.weave.core('alerts.follows.response-reward',
-          data.display_name, await $.points.str(reward)))
-      } else {
-        $.shout($.weave.core('alerts.follows.response-no-reward',
-          data.display_name))
-      }
-
-      $.cache.set('events', events)
-    }
-  }
-}
-
 function listen () {
   transit.removeListener('alert:follow', followHandler)
   transit.removeListener('alert:host', hostHandler)
@@ -144,6 +123,29 @@ function listen () {
   transit.on('alert:tip', tipHandler)
 }
 
+async function followHandler (data) {
+  const events = $.cache.get('events', [])
+
+  if (await $.settings.get('followAlerts', true)) {
+    if (!events.includes(`${data.display_name}:follow`)) {
+      events.push(`${data.display_name}:follow`)
+      const reward = await $.settings.get('followReward', 50)
+
+      if (reward > 0) {
+        $.shout($.weave(
+          'alerts.follows.response-reward',
+          data.display_name,
+          await $.points.str(reward)
+        ))
+      } else {
+        $.shout($.weave('alerts.follows.response-no-reward', data.display_name))
+      }
+
+      $.cache.set('events', events)
+    }
+  }
+}
+
 async function hostHandler (data) {
   const events = $.cache.get('events', [])
 
@@ -154,11 +156,14 @@ async function hostHandler (data) {
       const reward = await $.settings.get('hostReward', 50)
 
       if (reward > 0) {
-        $.shout($.weave.core('bot:settings:alerts-hosts:response-reward',
-                    data.display_name, data.viewers, await $.points.str(reward)))
+        $.shout($.weave(
+          'alerts.host.response-reward',
+          data.display_name,
+          data.viewers,
+          await $.points.str(reward)
+        ))
       } else {
-        $.shout($.weave.core('bot:settings:alerts-hosts:response-no-reward',
-                    data.display_name, data.viewers))
+        $.shout($.weave('alerts.host.response-no-reward', data.display_name, data.viewers))
       }
 
       $.cache.set('events', events)
@@ -178,20 +183,27 @@ async function subHandler (data) {
       if (data.hasOwnProperty('months')) {
         // Event is a resub
         if (reward > 0) {
-          response = $.weave.core('bot:settings:alerts-resubs:response-reward',
-                        data.display_name, data.months, await $.points.str(reward))
+          response = $.weave(
+            'alerts.sub.resub-reward',
+            data.display_name,
+            data.months,
+            await $.points.str(reward)
+          )
         } else {
-          response = $.weave.core('bot:settings:alerts-resubs:response-no-reward',
-                        data.display_name, data.months)
+          response = $.weave(
+            'alerts.sub.resub-no-reward',
+            data.display_name,
+            data.months
+          )
         }
       } else {
         // Event is a new subscription
         if (reward > 0) {
-          response = $.weave.core('bot:settings:alerts-subs:response-reward',
-                        data.display_name, await $.points.str(reward))
+          response = $.weave(
+            'alerts.sub.response-reward', data.display_name, await $.points.str(reward)
+          )
         } else {
-          response = $.weave.core('bot:settings:alerts-subs:response-no-reward',
-                        data.display_name)
+          response = $.weave('alerts.sub.response-no-reward', data.display_name)
         }
       }
 
@@ -207,11 +219,14 @@ async function tipHandler (data) {
     const reward = await $.settings.get('tipReward', 50)
 
     if (reward > 0) {
-      $.shout($.weave.core('bot:settings:alerts-tips:response-reward',
-                data.name, data.amount, await $.points.str(reward)))
+      $.shout($.weave(
+        'alerts.tip.response-reward',
+        data.name,
+        data.amount,
+        await $.points.str(reward)
+      ))
     } else {
-      $.shout($.weave.core('bot:settings:alerts-tips:response-no-reward',
-                data.name, data.amount))
+      $.shout($.weave('alerts.tip.response-no-reward', data.name, data.amount))
     }
   }
 }

--- a/src/main/components/bot/extensions/points/ext.json
+++ b/src/main/components/bot/extensions/points/ext.json
@@ -6,7 +6,7 @@
     "module": "./module.js",
     "component": "./component.js",
     "interface": "",
-    "language": ""
+    "language": "./lang.js"
   },
   "author": "citycide <thecitycide@gmail.com>",
   "homepage": "github.com/citycide/singularity"

--- a/src/main/components/bot/extensions/points/lang.js
+++ b/src/main/components/bot/extensions/points/lang.js
@@ -1,0 +1,14 @@
+export default function ($) {
+  $.weave.set('response', '{0} has {1}.')
+  $.weave.set('response.not-found', '{0} has not visited the chat yet.')
+
+  $.weave.set('add.usage', 'Usage: !points add (username) (amount)')
+  $.weave.set('remove.usage', 'Usage: !points remove (username) (amount)')
+  $.weave.set('change.success', '{0} now has {1}.')
+
+  $.weave.set('gift.usage', 'Usage: !points gift (username) (amount)')
+  $.weave.set('gift.not-enough-points', 'You only have {0}.')
+  $.weave.set('gift.success.sender', 'You gave {0} to {1} » {2} remaining')
+  $.weave.set('gift.success.recipient', '{0} gave you {1} » you now have {2}')
+  $.weave.set('gift.success.shout', '{1} gave {1} to {2} » {3} remaining')
+}

--- a/src/main/components/bot/extensions/points/lang.js
+++ b/src/main/components/bot/extensions/points/lang.js
@@ -10,5 +10,5 @@ export default function ($) {
   $.weave.set('gift.not-enough-points', 'You only have {0}.')
   $.weave.set('gift.success.sender', 'You gave {0} to {1} » {2} remaining')
   $.weave.set('gift.success.recipient', '{0} gave you {1} » you now have {2}')
-  $.weave.set('gift.success.shout', '{1} gave {1} to {2} » {3} remaining')
+  $.weave.set('gift.success.shout', '{0} gave {1} to {2} » {3} remaining')
 }

--- a/src/main/components/bot/extensions/points/module.js
+++ b/src/main/components/bot/extensions/points/module.js
@@ -2,67 +2,68 @@ export async function points (e, $) {
   const [action, param1, param2] = e.args
 
   if (!action) {
-    return $.say(e.sender, `You have ${await $.points.get(e.sender, true)}.`)
+    return $.say(e.sender, $.weave('response', e.sender, await $.points.get(e.sender, true)))
   }
 
   if ($.is(e.subcommand, 'add')) {
     if (e.args.length < 3 || !$.is.numeric(param2)) {
-      $.say(e.sender, `Usage: !points add [username] [amount]`)
+      $.say(e.sender, $.weave('add.usage'))
       return
     }
 
     await $.points.add(param1, param2)
-    $.say(e.sender, `${param1} now has ${await $.points.get(param1, true)}.`)
+    $.say(e.sender, $.weave('change.success', param1, await $.points.get(param1, true)))
 
     return
   }
 
   if ($.is(e.subcommand, 'remove')) {
     if (e.args.length < 3 || !$.is.numeric(param2)) {
-      $.say(e.sender, `Usage: !points remove [username] [amount]`)
+      $.say(e.sender, $.weave('remove.usage'))
       return
     }
 
     await $.points.sub(param1, param2)
-    $.say(e.sender, `${param1} now has ${await $.points.get(param1, true)}.`)
+    $.say(e.sender, $.weave('change.success', param1, await $.points.get(param1, true)))
 
     return
   }
 
   if ($.is(e.subcommand, 'gift')) {
     if (e.args.length < 3 || !$.is.numeric(param2)) {
-      $.say(e.sender, `Usage: !points gift [username] [amount]`)
+      $.say(e.sender, $.weave('gift.usage'))
       return
     }
 
     if ($.points.get(e.sender) < $.to.number(param2, true)) {
-      $.say(e.sender, `You only have ${await $.points.get(e.sender, true)}.`)
+      $.say(e.sender, $.weave('gift.not-enough-points', await $.points.get(e.sender, true)))
       return
     }
 
     await $.points.sub(e.sender, param2)
     await $.points.add(param1, param2)
 
+    const str = $.points.str(param2)
     if ($.settings.get('whisperMode')) {
-      $.whisper(e.sender,
-        `You gave ${$.points.str(param2)} to ${param1} ` +
-        `(${await $.points.get(e.sender, true)} left)`)
-      $.whisper(param1,
-        `${e.sender} gave you ${$.points.str(param2)} ` +
-        `(you now have ${await $.points.get(e.sender, true)})`)
+      $.whisper(e.sender, $.weave(
+        'gift.success.sender', str, param1, await $.points.get(e.sender, true)
+      ))
+      $.whisper(param1, $.weave(
+        'gift.success.recipient', e.sender, str, await $.points.get(param1, true)
+      ))
     } else {
-      $.say(e.sender,
-        `You gave ${$.points.str(param2)} to ${param1} ` +
-        `(${await $.points.get(e.sender, true)} left)`)
+      $.shout($.weave(
+        'gift.success.shout', e.sender, str, param1, await $.points.get(e.sender, true)
+      ))
     }
 
     return
   }
 
   if (await $.user.exists(action)) {
-    return $.say(e.sender, `${action} has ${await $.points.get(action, true)}.`)
+    return $.say(e.sender, $.weave('response', action, await $.points.get(action, true)))
   } else {
-    return $.say(e.sender, `${action} hasn't visited the chat yet.`)
+    return $.say(e.sender, $.weave('response.not-found', action))
   }
 }
 

--- a/src/main/components/bot/extensions/quotes/ext.json
+++ b/src/main/components/bot/extensions/quotes/ext.json
@@ -6,7 +6,7 @@
     "module": "./module.js",
     "component": "./component.js",
     "interface": "",
-    "language": ""
+    "language": "./lang.js"
   },
   "author": "citycide <thecitycide@gmail.com>",
   "homepage": "github.com/citycide/singularity"

--- a/src/main/components/bot/extensions/quotes/lang.js
+++ b/src/main/components/bot/extensions/quotes/lang.js
@@ -14,6 +14,7 @@ export default function ($) {
   $.weave.set('edit.failure', 'Failed to edit quote #{0}.')
   
   $.weave.set('response', `"{0}" - {1} ({2}{3})`)
+  $.weave.set('response.not-found', 'Quote #{0} does not exist.')
   
   $.weave.set('help',
     `To save a quote, use '!quote add Something really wise.' ` +

--- a/src/main/components/bot/extensions/quotes/lang.js
+++ b/src/main/components/bot/extensions/quotes/lang.js
@@ -1,0 +1,22 @@
+export default function ($) {
+  $.weave.set('usage', 'Usage: !quote (add | remove | edit | help)')
+
+  $.weave.set('add.usage', 'Usage: !quote add Something really wise. [~username]')
+  $.weave.set('add.success', 'Quote added as #{0}')
+  $.weave.set('add.failure', 'Failed to add quote.')
+
+  $.weave.set('remove.usage', 'Usage: !quote remove (number >= 1)')
+  $.weave.set('remove.success', 'Quote removed. {0} quotes remaining.')
+  $.weave.set('remove.failure', 'Failed to remove quote #{0}.')
+  
+  $.weave.set('edit.usage', 'Usage: !quote edit (number >= 1) (message) [~username]')
+  $.weave.set('edit.success', 'Quote #{0} modified.')
+  $.weave.set('edit.failure', 'Failed to edit quote #{0}.')
+  
+  $.weave.set('response', `"{0}" - {1} ({2}{3})`)
+  
+  $.weave.set('help',
+    `To save a quote, use '!quote add Something really wise.' ` +
+    `To credit who said it, add '~username' with no space.`
+  )
+}

--- a/src/main/components/bot/extensions/rekt/ext.json
+++ b/src/main/components/bot/extensions/rekt/ext.json
@@ -6,7 +6,7 @@
     "module": "./module.js",
     "component": "",
     "interface": "",
-    "language": ""
+    "language": "./lang.js"
   },
   "author": "citycide <thecitycide@gmail.com>",
   "homepage": "github.com/citycide/singularity"

--- a/src/main/components/bot/extensions/rekt/lang.js
+++ b/src/main/components/bot/extensions/rekt/lang.js
@@ -1,0 +1,17 @@
+export default function ($) {
+  $.weave.set('usage', 'Usage: !rekt (add | remove | edit)')
+  $.weave.set('no-response', `I'm not going to dignify that with a response.`)
+  $.weave.set('not-found', 'There is no !rekt response with ID #{0}.')
+
+  $.weave.set('add.usage', 'Usage: !rekt add (message)')
+  $.weave.set('add.success', 'rekt response added as #{0}.')
+  $.weave.set('add.failure', 'Failed to add rekt response.')
+
+  $.weave.set('remove.usage', 'Usage: !rekt remove (number >= 1)')
+  $.weave.set('remove.success', 'rekt response removed. {0} responses remaining.')
+  $.weave.set('remove.failure', 'Failed to remove rekt response #{0}.')
+  
+  $.weave.set('edit.usage', 'Usage: !rekt edit (number >= 1) (message)')
+  $.weave.set('edit.success', 'rekt response #{0} modified.')
+  $.weave.set('edit.failure', 'Failed to edit rekt response #{0}.')
+}

--- a/src/main/components/bot/extensions/rekt/module.js
+++ b/src/main/components/bot/extensions/rekt/module.js
@@ -15,7 +15,7 @@ export async function rekt (e, $) {
     if (response) {
       $.say(e.sender, $.params(e, response.value))
     } else {
-      $.say(e.sender, `I'm not going to dignify that with a response.`)
+      $.say(e.sender, $.weave('not-found'))
     }
 
     return
@@ -23,7 +23,7 @@ export async function rekt (e, $) {
 
   if ($.is(e.subcommand, 'add')) {
     if (!e.subArgs[0]) {
-      $.say(e.sender, `Usage: !rekt add (message)`)
+      $.say(e.sender, $.weave('add.usage'))
       return
     }
 
@@ -33,9 +33,9 @@ export async function rekt (e, $) {
     const id = res ? res.id : false
 
     if (id) {
-      $.say(e.sender, `rekt response added as #${id}.`)
+      $.say(e.sender, $.weave('add.success', id))
     } else {
-      $.say(e.sender, `Failed to add rekt response.`)
+      $.say(e.sender, $.weave('add.failure'))
     }
 
     return
@@ -43,16 +43,21 @@ export async function rekt (e, $) {
 
   if ($.is(e.subcommand, 'remove')) {
     if (!e.subArgs[0]) {
-      $.say(e.sender, `Usage: !rekt remove (number >/= 1)`)
+      $.say(e.sender, $.weave('remove.usage'))
+      return
+    }
+
+    if (!await $.db.exists('rekt', { id: e.subArgs[0] })) {
+      $.say(e.sender, $.weave('not-found', e.subArgs[0]))
       return
     }
 
     const id = parseInt(e.subArgs[0])
     if (await $.db.del('rekt', { id })) {
       const count = $.db.countRows('rekt')
-      $.say(e.sender, `rekt response removed. ${count} responses remaining.`)
+      $.say(e.sender, $.weave('remove.success', count))
     } else {
-      $.say(e.sender, `Failed to remove rekt response #${id}.`)
+      $.say(e.sender, $.weave('remove.failure', id))
     }
 
     return
@@ -60,12 +65,12 @@ export async function rekt (e, $) {
 
   if ($.is(e.subcommand, 'edit')) {
     if (!e.subArgs.length < 2) {
-      $.say(e.sender, `Usage: !rekt edit (number >/= 1) (message)`)
+      $.say(e.sender, $.weave('edit.usage'))
       return
     }
 
     if (!await $.db.exists('rekt', { id: e.subArgs[0] })) {
-      $.say(e.sender, `There is no !rekt response with ID #${e.subArgs[0]}.`)
+      $.say(e.sender, $.weave('not-found', e.subArgs[0]))
       return
     }
 
@@ -73,9 +78,9 @@ export async function rekt (e, $) {
     const value = e.subArgs.slice(1).join(' ')
 
     if (await $.db.set('rekt', { value }, { id })) {
-      $.say(e.sender, `rekt response #${id} modified.`)
+      $.say(e.sender, $.weave('edit.success', id))
     } else {
-      $.say(e.sender, `Failed to edit rekt response #${id}.`)
+      $.say(e.sender, $.weave('edit.failure', id))
     }
   }
 }

--- a/src/main/components/bot/helpers/logger.js
+++ b/src/main/components/bot/helpers/logger.js
@@ -1,16 +1,26 @@
 import path from 'path'
 import moment from 'moment'
+import { each } from 'lodash'
 import callsites from 'callsites'
+import appLog from 'common/utils/logger'
+
+const logTypes = {
+  error: 0,
+  event: 1,
+  debug: 2,
+  trace: 3
+}
 
 const log = function (file, data) {
-  $.file.write(file, `${moment().format('LTS L')} :: ${data}`, true)
+  const line = `${moment().format('LTS L')} :: ${data}`
+  $.file.write(file, line, true)
+  appLog.bot(line)
 }
 
 log.level = 1
 
 log.clear = function (file) {
   if (!$.file.exists(file)) return
-
   $.file.write(file, '')
 }
 
@@ -20,34 +30,28 @@ log.getLevel = function () {
 
 log.setLevel = function (level) {
   level = parseInt(level)
-  if (typeof level !== 'number') return
+  if (typeof level !== 'number') {
+    level = logTypes[level] || 1
+  }
   log.level = level
 }
 
-const logTypes = {
-  error: 0,
-  event: 1,
-  debug: 2,
-  trace: 3
-}
+Object.keys(logTypes).map(type => {
+  log[type] = function (file, data) {
+    if (log.getLevel() < logTypes[type]) return
 
-;(function () {
-  for (let type of Object.keys(logTypes)) {
-    // eslint-disable-next-line
-    log[type] = function (file, data) {
-      if (log.getLevel() < logTypes[type]) return
+    const traced = callsites()[1]
+    const fileName = path.basename(traced.getFileName())
+    const lineNum = traced.getLineNumber()
+    const colNum = traced.getColumnNumber()
 
-      const traced = callsites()[1]
-      const fileName = path.basename(traced.getFileName())
-      const lineNum = traced.getLineNumber()
-      const colNum = traced.getColumnNumber()
-
-      const outPath = `${type}/${file}`
-      $.file.write(outPath, `${moment()
-      .format('LTS L')} :: ${fileName} (${lineNum}, ${colNum}) -> ${data}`, true)
-    }
+    const outPath = `${type}/${file}`
+    const time = moment().format('LTS L')
+    const line = `${time} :: ${fileName} (${lineNum}, ${colNum}) -> ${data}`
+    $.file.write(outPath, line, true)
+    appLog.bot(line)
   }
-})()
+}
 
 export default log
 

--- a/src/main/components/bot/helpers/logger.js
+++ b/src/main/components/bot/helpers/logger.js
@@ -1,6 +1,5 @@
 import path from 'path'
 import moment from 'moment'
-import { each } from 'lodash'
 import callsites from 'callsites'
 import appLog from 'common/utils/logger'
 


### PR DESCRIPTION
Use path resolution alias when importing the logger. Use `map` instead of `for..of` when loading custom commands.
